### PR TITLE
Optimize smaller_hash func

### DIFF
--- a/src/winnowing.c
+++ b/src/winnowing.c
@@ -65,13 +65,38 @@ void shift_gram(uint8_t *gram)
 	gram[GRAM - 1] = 0;
 }
 
-/* Select smaller hash for the given window */
+/* Select smaller hash for the given window.
+   Notice that there is only (1 / WINDOW) probability in which the last-time smallest hash
+   is left-shifted out. On other words, in most case, we can just compare the left-shifted-in (rightmost)
+   one with last-time smallest one. Using this fact we can reduce the average compare times from WINDOW to
+   1 + (1 / WINDOW) * WINDOW = 2 */
+static int32_t last_smallest_ptr = 0; // record last time the position of the smallest hash
 uint32_t smaller_hash(uint32_t *window)
 {
-	uint32_t hash = MAX_UINT32;
-	for (uint32_t h = 0; h < WINDOW; h++)
+	last_smallest_ptr--; // Last time the window left shift by 1, so decrease by 1.
+	uint32_t hash;
+	if (last_smallest_ptr <= -1) // If the last smallest hash was left-shifted out.
 	{
-		if (window[h] < hash) hash = window[h];
+		hash = window[0];
+		last_smallest_ptr = 0;
+		for (uint32_t h = 1; h < WINDOW; h++) // scan all the WINDOW to find the smallest.
+		{
+			if (window[h] < hash)
+			{
+				hash = window[h];
+				last_smallest_ptr = h;
+			}
+		}
+	}
+	else
+	{ // If the last smallest hash is still in this WINDOW just compare it with the new (rightmost) one.
+
+		hash = window[last_smallest_ptr];
+		if (window[WINDOW - 1] < hash)
+		{
+			hash = window[WINDOW - 1];
+			last_smallest_ptr = WINDOW - 1;
+		}
 	}
 	return hash;
 }


### PR DESCRIPTION
Optimize smaller_hash func by the fact that in most case, we can just compare the left-shifted-in (rightmost) one with last-time smallest one.

Notice that there is only (1 / WINDOW) probability in which the last-time smallest hash
is left-shifted out. On other words, in most case, we can just compare the left-shifted-in (rightmost)
one with last-time smallest one. Using this fact we can reduce the average compare times from WINDOW to
1 + (1 / WINDOW) * WINDOW = 2.

I generate a 109M benchmark data, On my 2.71 GHz Intel Core i7 8559U CPU, 32 GB 2400 MHz DDR4 computer:

The performance was improved from 9.5s to 9.1s. (3 times running for average)

Improved performance by about 4.2%，but At the cost of increased code complexity a bit. Do you think it's worthy? please let me know.

I am not skilled C-programer, if there is any problem, feel free to point it out.